### PR TITLE
matching primitives without using toString

### DIFF
--- a/src/main/scala/com/flextrade/jfixture/internal/ScalaPrimitivesBuilder.scala
+++ b/src/main/scala/com/flextrade/jfixture/internal/ScalaPrimitivesBuilder.scala
@@ -1,26 +1,18 @@
 package com.flextrade.jfixture.internal
 
-import com.flextrade.jfixture.utility.SpecimenType
 import com.flextrade.jfixture.{NoSpecimen, SpecimenBuilder, SpecimenContext}
 
-import scala.reflect.runtime.universe.{Type => ScalaType}
+import scala.reflect.runtime.universe.{runtimeMirror, Type => ScalaType}
 
 class ScalaPrimitivesBuilder extends SpecimenBuilder {
+
+  private val mirror = runtimeMirror(classOf[ScalaPrimitivesBuilder].getClassLoader)
+
   override def create(request: Any, context: SpecimenContext): AnyRef = {
     request match {
-      case request: SpecimenType[_] => request.toString match {
-        case "scala.Int" => context.resolve(classOf[Integer])
-        case "scala.Double" => context.resolve(classOf[Double])
-        case "scala.Byte" => context.resolve(classOf[Byte])
-        case "scala.Long" => context.resolve(classOf[Long])
-        case _ => new NoSpecimen
-      }
-
-      case sym: ScalaType => context.resolve(typeToClass(sym))
+      case tpe: ScalaType => context.resolve(mirror.runtimeClass(tpe.typeSymbol.asClass))
       case _ => new NoSpecimen
     }
   }
-
-  private def typeToClass(tpe: ScalaType) = Class.forName(tpe.typeSymbol.fullName)
 
 }


### PR DESCRIPTION
claassOf[Int] results in java primitive "int" at runtime hence why "case x if x == classOf[Int]" doesn't work