### PR TITLE
Support Scala 2.13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,7 @@
+lazy val scala213 = "2.13.8"
 lazy val scala212 = "2.12.9"
 lazy val scala211 = "2.11.7"
-lazy val supportedScalaVersions = List(scala212, scala211)
+lazy val supportedScalaVersions = List(scala213, scala212, scala211)
 
 ThisBuild / organization := "com.flextrade.jfixture"
 ThisBuild / name         := "jfixture-scala"

--- a/src/main/scala/com/flextrade/jfixture/internal/ClassTagCollectionRelay.scala
+++ b/src/main/scala/com/flextrade/jfixture/internal/ClassTagCollectionRelay.scala
@@ -1,11 +1,9 @@
 package com.flextrade.jfixture.internal
 
-import java.util
-
 import com.flextrade.jfixture.requests.MultipleRequest
 import com.flextrade.jfixture.{NoSpecimen, SpecimenBuilder, SpecimenContext}
 
-import scala.collection.JavaConversions._
+import java.util
 import scala.reflect.runtime.universe.{Type => ScalaType, _}
 
 class ClassTagCollectionRelay extends SpecimenBuilder {
@@ -19,7 +17,7 @@ class ClassTagCollectionRelay extends SpecimenBuilder {
     case tpeTag: ScalaType =>
       val args = tpeTag.typeArgs
       if (args.size < 1) return NoSpecimen
-      val collection = context.resolve(new MultipleRequest(args.head)).asInstanceOf[util.Collection[_]]
+      val collection = context.resolve(new MultipleRequest(args.head)).asInstanceOf[util.Collection[_]].toArray
 
       tpeTag.typeSymbol match {
         case ListSymbol => collection.toList

--- a/src/main/scala/com/flextrade/jfixture/internal/ScalaCollectionRelay.scala
+++ b/src/main/scala/com/flextrade/jfixture/internal/ScalaCollectionRelay.scala
@@ -1,18 +1,16 @@
 package com.flextrade.jfixture.internal
 
-import java.util
-
 import com.flextrade.jfixture.requests.MultipleRequest
 import com.flextrade.jfixture.utility.SpecimenType
 import com.flextrade.jfixture.{NoSpecimen, SpecimenBuilder, SpecimenContext}
 
-import scala.collection.JavaConversions._
+import java.util
 
 class ScalaCollectionRelay extends SpecimenBuilder {
   override def create(request: scala.Any, context: SpecimenContext): AnyRef = request match {
     case request: SpecimenType[_] if request.getGenericTypeArguments.getLength >= 1 =>
       val itemType = request.getGenericTypeArguments.get(0).getType
-      val collection = context.resolve(new MultipleRequest(SpecimenType.of(itemType))).asInstanceOf[util.Collection[_]]
+      val collection = context.resolve(new MultipleRequest(SpecimenType.of(itemType))).asInstanceOf[util.Collection[_]].toArray
       request.getRawType match {
         case ScalaRelays.ListClass => collection.toList
         case ScalaRelays.SetClass => collection.toSet


### PR DESCRIPTION
The current implementation of jfixture-scala requires the implicit collection converters, which are changed in Scala 2.13

This makes it unusable in Scala 2.13.  The proposed solution replaces the implicit conversion with explicit conversion via an Array, which is probably slower, but will work across scala versions without having to have different imports on each version.